### PR TITLE
#3 Declare missing abstract methods for Craft 3.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.2 - 2019-07-14
+### Fixed
+- Updated to support Craft 3.2 (thanks [ajoliveau](https://github.com/ajoliveau)).
+
 ## 1.1.1 - 2019-06-27 [CRITICAL]
 ### Fixed
 - Project Config event handlers are now applied to the extended fields service, this resolves an issue where matrix fields weren't being saved

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "thejoshsmith/craft-fab-permissions",
     "description": "Give yourself better control over your sections with Craft Field and Tab (FAB) Permissions. Restrict which tabs and fields are visible to different user groups.",
     "type": "craft-plugin",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "keywords": [
         "craft",
         "cms",

--- a/src/base/FieldDecorator.php
+++ b/src/base/FieldDecorator.php
@@ -77,7 +77,6 @@ abstract class FieldDecorator extends Decorator implements FieldInterface {
 		return parent::afterDelete();
 	}
 
-
 	// FieldInterface
 	public static function hasContentColumn(): bool
 	{
@@ -87,6 +86,11 @@ abstract class FieldDecorator extends Decorator implements FieldInterface {
 	public static function supportedTranslationMethods(): array
 	{
 		return Field::supportedTranslationMethods();
+	}
+
+	public static function valueType(): string
+	{
+		return Field::valueType();
 	}
 
 	public function getContentColumnType(): string
@@ -167,6 +171,11 @@ abstract class FieldDecorator extends Decorator implements FieldInterface {
 	public function afterElementSave(ElementInterface $element, bool $isNew)
 	{
 		return parent::afterElementSave($element, $isNew);
+	}
+
+	public function afterElementPropagate(ElementInterface $element, bool $isNew)
+	{
+		return parent::afterElementPropagate($element, $isNew);
 	}
 
 	public function beforeElementDelete(ElementInterface $element): bool

--- a/src/decorators/StaticFieldDecorator.php
+++ b/src/decorators/StaticFieldDecorator.php
@@ -23,13 +23,5 @@ class StaticFieldDecorator extends FieldDecorator {
 	public function getInputHtml($value, ElementInterface $element = null): string
 	{
 		return parent::getStaticHtml($value, $element);
-    }
-    
-    public function afterElementPropagate(ElementInterface $element, bool $isNew) {
-
-    }
-
-    public static function valueType() : string {
-        return 'mixed';
-    }
+	}
 }

--- a/src/decorators/StaticFieldDecorator.php
+++ b/src/decorators/StaticFieldDecorator.php
@@ -23,5 +23,13 @@ class StaticFieldDecorator extends FieldDecorator {
 	public function getInputHtml($value, ElementInterface $element = null): string
 	{
 		return parent::getStaticHtml($value, $element);
-	}
+    }
+    
+    public function afterElementPropagate(ElementInterface $element, bool $isNew) {
+
+    }
+
+    public static function valueType() : string {
+        return 'mixed';
+    }
 }


### PR DESCRIPTION
Two new abstract methods in FieldInterface are missing from StaticFieldDecorator : 

- [`afterElementPropagate`](https://github.com/craftcms/cms/commit/a52e404638174ac1a962ad027e867422816e2d0f#diff-00d10722e292e09070c0c9fb8399f219) which allows the plugin to run some code after an element propagates. I don't think this plugin wants do to that so the method is empty
- [`valueType`](https://github.com/craftcms/cms/issues/3894) that returns the specific type of the Field and is used for syntaxic autocompletion in code editors. This plugin's users wouldn't need to touch the `StaticFieldDecorator` class so I think it makes sense to keep the default `mixed`