### PR TITLE
Update the Fields service to be compatible with Craft v3.5

### DIFF
--- a/src/base/FieldDecorator.php
+++ b/src/base/FieldDecorator.php
@@ -173,6 +173,16 @@ abstract class FieldDecorator extends Decorator implements FieldInterface {
         return parent::getContentGqlType();
     }
 
+    public function getContentGqlMutationArgumentType()
+    {
+        return parent::getContentGqlMutationArgumentType();
+    }
+
+    public function getContentGqlQueryArgumentType()
+    {
+        return parent::getContentGqlQueryArgumentType();
+    }
+
 	public function beforeElementSave(ElementInterface $element, bool $isNew): bool
 	{
 		return parent::beforeElementSave($element, $isNew);

--- a/src/services/Fields.php
+++ b/src/services/Fields.php
@@ -61,6 +61,18 @@ class Fields extends CraftFieldsService
         foreach ($tabs as $i => $tab) {
             if( !$fabService->canViewTab($tab, $user) ){
                 unset($tabs[$i]);
+            } elseif (isset($tab->elements)) {
+                foreach ($tab->elements as $j => $element) {
+                    if (!($element instanceof \craft\fieldlayoutelements\CustomField)) {
+                        continue;
+                    }
+                    $field = $element->getField();
+                    if (!$fabService->canViewField($layoutId, $field, $user)) {
+                        unset($tab->elements[$j]);
+                    } elseif (!$fabService->canEditField($layoutId, $field, $user)) {
+                        $element->setField(new StaticFieldDecorator($field));
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
These changes make the plugin compatible with Craft 3.5 for existing fab permissions data. They do not address compatibility issues with the control panel UI.