### PR TITLE
Update installation instructions to use web-only config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To install the plugin, follow these instructions.
 
 3. In the Control Panel, go to Settings → Plugins and click the “Install” button for FAB Permissions.
 
-4. **Important** - Override the Craft Fields Service with the FAB Permissions Fields Service in `config/app.php`:
+4. **Important** - Override the Craft Fields Service with the FAB Permissions Fields Service in `config/app.web.php`:
 
 		return [
 			'components' => [


### PR DESCRIPTION
The fields service config can break console commands that use the fields service because when running on the console the object returned by `Craft::$app->getUser()` is `craft\console\User` and not `craft\web\User`.  Since you are generally running console commands as admin, configuring the fields service to run only in the web context solves this issue.

Fixes #13