### PR TITLE
Base compatibility with Craft 3.6

### DIFF
--- a/src/base/FieldDecorator.php
+++ b/src/base/FieldDecorator.php
@@ -9,6 +9,7 @@ use craft\base\FieldInterface;
 use craft\base\ElementInterface;
 use craft\elements\db\ElementQuery;
 use craft\elements\db\ElementQueryInterface;
+use craft\models\GqlSchema;
 
 /**
  * Abstract decorator that implements the field interface so decorated fields can be used internally
@@ -113,6 +114,11 @@ abstract class FieldDecorator extends Decorator implements FieldInterface {
 		return parent::getTranslationKey($element);
 	}
 
+	public function useFieldset(): bool
+	{
+		return parent::useFieldset();
+	}
+
 	public function getInputHtml($value, ElementInterface $element = null): string
 	{
 		return parent::getInputHtml($value, $element);
@@ -166,6 +172,11 @@ abstract class FieldDecorator extends Decorator implements FieldInterface {
 	public function getGroup()
 	{
 		return parent::getGroup();
+	}
+
+	public function includeInGqlSchema(GqlSchema $schema): bool
+	{
+		return parent::includeInGqlSchema($schema);
 	}
 
     public function getContentGqlType()


### PR DESCRIPTION
This is just what's required to get it not to error when visiting an entry in the control panel. I don't know if it's a complete compatibility fix yet, but it seems to function so far. I'll update this pull request if anything further comes up.