### PR TITLE
Update the FieldDecorator to be compatible with Craft v3.7

### DIFF
--- a/src/base/FieldDecorator.php
+++ b/src/base/FieldDecorator.php
@@ -228,4 +228,19 @@ abstract class FieldDecorator extends Decorator implements FieldInterface {
 	{
 		return parent::getContentGqlQueryArgumentType();
 	}
+
+    public function copyValue(ElementInterface $from, ElementInterface $to): void
+    {
+        parent::copyValue($from, $to);
+    }
+
+    public function getOrientation(?ElementInterface $element): string
+    {
+        return parent::getOrientation($element);
+    }
+
+    public function getStatus(ElementInterface $element): ?array
+    {
+        return parent::getStatus($element);
+    }
 }


### PR DESCRIPTION
When upgrading from Craft 3.6 to 3.7 I got a 500 error when trying to create a new entry with a user that does not have edit permissions for all fields of the entry.

Error message in the logs:

> PHP Fatal error:  Class thejoshsmith\fabpermissions\decorators\StaticFieldDecorator contains 3 abstract methods and must therefore be declared abstract or implement the remaining methods (craft\base\FieldInterface::getOrientation, craft\base\FieldInterface::getStatus, craft\base\FieldInterface::copyValue) in /var/app/vendor/thejoshsmith/craft-fab-permissions/src/decorators/StaticFieldDecorator.php on line 9

This PR adds those three missing FieldInterface functions.